### PR TITLE
Catching NPE in SessionParser and throwing AccedoOneException instead…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+v1.1.1 (2021-02-04)
+
+* Catching NullPointer in SessionParser
+
 v1.1.0 (2020-11-XX)
 
 * Renamed one-sdk module to control-sdk

--- a/control-sdk/build.gradle
+++ b/control-sdk/build.gradle
@@ -1,5 +1,5 @@
 group = 'tv.accedo.one'
-version = '1.1.0'
+version = '1.1.1'
 
 apply plugin: 'com.android.library'
 

--- a/control-sdk/src/main/java/tv/accedo/one/sdk/implementation/parsers/SessionParser.java
+++ b/control-sdk/src/main/java/tv/accedo/one/sdk/implementation/parsers/SessionParser.java
@@ -32,7 +32,7 @@ public class SessionParser implements ThrowingParser<Response, Pair<String, Long
             long sessionExpiration = expiration.getTime();
             return new Pair<String, Long>(session, sessionExpiration);
             
-        } catch (ParseException | JSONException e) {
+        } catch (ParseException | JSONException | NullPointerException e) {
             throw new AccedoOneException(StatusCode.NO_SESSION, e);
         }
     }


### PR DESCRIPTION
SessionParser.java line 28 Fatal Exception: java.lang.NullPointerException Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference

…. More details in Jira on TVCAPLATFORM-2101.

