### PR TITLE
Making okHttpResponse reachable in Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+v1.3.5 (2024-09-19)
+
+* Making okHttpResponse available in the Response object, which allows you to read the details of the Request including cache headers.
+
 v1.3.4 (2024-06-18)
 
 * Fix null check for request payloads

--- a/control-sdk/build.gradle.kts
+++ b/control-sdk/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "tv.accedo.one"
-version = "1.3.4"
+version = "1.3.5"
 
 android {
     namespace = "tv.accedo.one.sdk"

--- a/control-sdk/src/main/java/tv/accedo/one/sdk/implementation/utils/Response.java
+++ b/control-sdk/src/main/java/tv/accedo/one/sdk/implementation/utils/Response.java
@@ -40,6 +40,7 @@ public class Response {
     private final Map<String, List<String>> headers = new HashMap<>();
     @Nullable
     private Exception caughtException;
+    private okhttp3.Response okHttpResponse;
 
     /**
      * @return the response code, or -1 if no connection was made
@@ -119,6 +120,13 @@ public class Response {
     }
 
     /**
+     * @return The okHttpResponse object, which contains more details about the request.
+     */
+    public okhttp3.Response getOkHttpResponse() {
+        return okHttpResponse;
+    }
+
+    /**
      * @return The exception caught during the creation of the urlConnection used, or during connection, or during the parsing of the response.
      */
     @Nullable
@@ -134,6 +142,7 @@ public class Response {
      * @param charset        the charset used, the default being {@link Request.charset}.
      */
     public Response(@NonNull okhttp3.Response okHttpResponse, @NonNull String url, @NonNull Charset charset) {
+        this.okHttpResponse = okHttpResponse;
         this.url = url;
         this.charset = charset;
 


### PR DESCRIPTION
Making okHttpResponse available in the Response object, which allows you to read the details of the Request including cache headers.

This is needed for us to check the `If-Modified-Since` header of the related request.
